### PR TITLE
fix: Make reactions non selectable text

### DIFF
--- a/client/apps/messenger/src/features/room/components/message/Reactions.tsx
+++ b/client/apps/messenger/src/features/room/components/message/Reactions.tsx
@@ -54,9 +54,10 @@ export default function MessageReactions({ id }: MessageReactionsProps): React.R
             alignItems="end"
             justifyContent={isUsersMessage ? "flex-end" : "flex-start"}
             position="absolute"
-            bottom={0}
+            bottom="-23px"
             zIndex={1}
             sx={{
+                userSelect: "none",
                 ...(isUsersMessage ? { right: 18 } : { left: 0 }),
             }}
         >
@@ -65,7 +66,6 @@ export default function MessageReactions({ id }: MessageReactionsProps): React.R
                 direction="row"
                 bgcolor={isUsersMessage ? "common.myMessageBackground" : "background.paper"}
                 position="relative"
-                top="23px"
                 px={0.75}
                 sx={{
                     borderRadius: "1rem",


### PR DESCRIPTION
[Task #1570](https://app.productive.io/9193-clover-studio/projects/114002/tasks/task/6933218?filter=LTM%3D)